### PR TITLE
Added feature to use webdriver_manager python lib to eliminate manual…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ idna==3.2
 requests==2.26.0
 selenium==3.141.0
 urllib3==1.26.6
+fake-useragent==0.1.11
+webdriver-manager==3.4.2


### PR DESCRIPTION
Installing the Chromedriver can be tedious and often makes it difficult for people new to Selenium to get things running. I found this awesome[ webdriver-manager package](https://pypi.org/project/webdriver-manager/) a few weeks ago, and it totally eliminates this step. I run Ubuntu 18.04 so I've only tested on that OS, but it should work with any OS per the webdriver-manager docs.

I also added in another dependency for fake-useragent and created a function for creating the chromedriver with some options that are helpful for making automation detection more difficult.