### PR TITLE
Adding to Linux section of FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -23,3 +23,4 @@
    # or
    sudo env "PATH=$PATH" ./main.py
    ```
+   You may also need to run the installation itself as sudo, e.g. `sudo pip3 install -r ./requirements.txt`


### PR DESCRIPTION
I'm running Linux Mint (20.2, based on Ubuntu) and also had to run the installation as `sudo`, even after copying over the PATH, in order to get things to run.

Added this suggestion to the FAQ under Linux/OSX issues. (I don't have an Mac to test with; this may be Linux-only.)